### PR TITLE
Add node shebang for npx

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 import chalk from 'chalk';
 import yargs from 'yargs';
 import Feeder from './feeder.js';


### PR DESCRIPTION
This PR adds the node shebang to the main entry file. This shebang is kept after running `npm run build`.

Running npx locally now works as expected:
```
npm install
npm run build
npx .
```